### PR TITLE
Fix routing

### DIFF
--- a/config/dev.webpack.config.js
+++ b/config/dev.webpack.config.js
@@ -7,20 +7,16 @@ const history = require('connect-history-api-fallback');
 const convert = require('koa-connect');
 
 webpackConfig.serve = {
-    content: config.paths.public,
-    port: 8002,
-    // Setting inline and hot to false disables websockets
-    inline: false,
-    hot: false,
-    host: '0.0.0.0',
-    dev: {
-        publicPath: '/insights/platform/service-portal'
-    },
-    // https://github.com/webpack-contrib/webpack-serve/blob/master/docs/addons/history-fallback.config.js
-    add: app => app.use(convert(history({})))
+  content: config.paths.public,
+  port: 8002,
+  dev: {
+    publicPath: '/insights/platform/service-portal'
+  },
+  // https://github.com/webpack-contrib/webpack-serve/blob/master/docs/addons/history-fallback.config.js
+  add: app => app.use(convert(history({})))
 };
 
 module.exports = _.merge({},
-    webpackConfig,
-    require('./dev.webpack.plugins.js')
+  webpackConfig,
+  require('./dev.webpack.plugins.js')
 );

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -18,6 +18,7 @@ import some from 'lodash/some';
  *         see the difference with DashboardMap and InventoryDeployments.
  *
  */
+
 const ServicePortal = asyncComponent(() => import('./SmartComponents/ServicePortal/ServicePortal'));
 const PlatformItems = asyncComponent(() => import('./SmartComponents/Platform/PlatformItems'));
 const PortfolioItems = asyncComponent(() => import('./SmartComponents/Portfolio/PortfolioItems'));
@@ -27,20 +28,19 @@ const Orders = asyncComponent(() => import('./SmartComponents/Order/Orders'));
 
 const paths = {
   service_portal: '/',
-  platform_items: '/platform_items/:filter?',
-  portfolio_items: '/portfolio_items/:filter?',
+  platform_items: '/platform_items/:id',
+  portfolio_items: '/portfolio_items/:id',
   portfolios: '/portfolios',
   portfolio: '/portfolios/:id',
   orders: '/orders'
 };
 
-const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
+const InsightsRoute = ({ rootClass, ...rest }) => {
   const root = document.getElementById('root');
   root.removeAttribute('class');
   root.classList.add(`page__${rootClass}`, 'pf-l-page__main');
   root.setAttribute('role', 'main');
-
-  return (<Component { ...rest } />);
+  return (<Route { ...rest } />);
 };
 
 InsightsRoute.propTypes = {
@@ -61,10 +61,10 @@ export const Routes = props => {
   return (
     <Switch>
       <InsightsRoute exact path={ paths.service_portal } component={ ServicePortal } rootClass="service_portal" />
-      <InsightsRoute exact path={ paths.platform_items } component={ PlatformItems } rootClass="platform_items" />
+      <InsightsRoute path={ paths.platform_items } component={ PlatformItems } rootClass="platform_items" />
       <InsightsRoute exact path={ paths.portfolio_items } component={ PortfolioItems } rootClass="portfolio_items" />
       <InsightsRoute exact path={ paths.portfolios } component={ Portfolios } rootClass="portfolios" />
-      <InsightsRoute exact path={ paths.portfolio } component={ Portfolio } rootClass="portfolio" />
+      <InsightsRoute path={ paths.portfolio } component={ Portfolio } rootClass="portfolio" />
       <InsightsRoute exact path={ paths.orders } component={ Orders } rootClass="service_portal" />
       { /* Finally, catch all unmatched routes */ }
       <Route render={ () => (some(paths, p => p === path) ? null : <Redirect to={ paths.service_portal } />) } />

--- a/src/SmartComponents/Platform/PlatformItems.js
+++ b/src/SmartComponents/Platform/PlatformItems.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import propTypes from 'prop-types';
-import { parse } from 'querystring';
 import { Main } from '@red-hat-insights/insights-frontend-components';
 import { fetchPlatformItems } from '../../Store/Actions/PlatformActions';
 import { Toolbar, ToolbarGroup, ToolbarItem, ToolbarSection } from '@patternfly/react-core';
@@ -21,11 +20,13 @@ class PlatformItems extends Component {
   }
 
   componentDidMount() {
-    let filter = this.props.computedMatch.params.filter;
-    console.log('PlatformItems filter: ', filter);
-    let parsed = parse(filter);
-    console.log('PlatformItems parsed filter: ', parsed);
-    this.fetchData(parsed);
+    this.fetchData(this.props.match.params.id);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.match.params.id !== this.props.match.params.id) {
+      this.fetchData(this.props.match.params.id);
+    }
   }
 
   renderToolbar() {

--- a/src/SmartComponents/Portfolio/Portfolio.js
+++ b/src/SmartComponents/Portfolio/Portfolio.js
@@ -40,9 +40,13 @@ class Portfolio extends Component {
   }
 
   componentDidMount() {
-    let portfolioId = this.props.computedMatch.params.id;
-    console.log('Portfolio Id: ', portfolioId);
-    this.fetchData(portfolioId);
+    this.fetchData(this.props.match.params.id);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.match.params.id !== this.props.match.params.id) {
+      this.fetchData(this.props.match.params.id);
+    }
   }
 
   onKebabToggle = isOpen => this.setState({ isKebabOpen: isOpen });
@@ -148,9 +152,4 @@ Portfolio.propTypes = {
   history: propTypes.object
 };
 
-export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(Portfolio)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Portfolio));

--- a/src/SmartComponents/Portfolio/PortfolioItems.js
+++ b/src/SmartComponents/Portfolio/PortfolioItems.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import propTypes from 'prop-types';
-import { parse } from 'querystring';
 import { Section } from '@red-hat-insights/insights-frontend-components';
 import { Toolbar, ToolbarGroup, ToolbarItem, ToolbarSection } from '@patternfly/react-core';
 import ContentGallery from '../../SmartComponents/ContentGallery/ContentGallery';
@@ -26,11 +25,14 @@ class PortfolioItems extends Component {
   }
 
   componentDidMount() {
-    let filter = this.props.computedMatch.params.filter;
-    console.log('PortfolioItems filter: ', filter);
-    let parsed = parse(filter);
-    console.log('PortfolioItems parsed filter: ', parsed);
-    this.fetchData(parsed);
+    this.fetchData(this.props.match.params.id);
+  }
+
+  // TODO: can be moved to redux action
+  componentDidUpdate(prevProps) {
+    if (prevProps.match.params.id !== this.props.match.params.id) {
+      this.fetchData(this.props.match.params.id);
+    }
   }
 
   renderToolbar() {
@@ -82,9 +84,4 @@ PortfolioItems.propTypes = {
   history: propTypes.object
 };
 
-export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(PortfolioItems)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(PortfolioItems));

--- a/src/SmartComponents/ServicePortal/PortalNav.js
+++ b/src/SmartComponents/ServicePortal/PortalNav.js
@@ -1,17 +1,17 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
+import { withRouter, NavLink } from 'react-router-dom';
+import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { bindMethods } from '../../Helpers/Shared/Helper';
 import { Nav, NavGroup, NavItem } from '@patternfly/react-core';
 import { fetchPlatforms } from '../../Store/Actions/PlatformActions';
 import { fetchPortfolios } from '../../Store/Actions/PortfolioActions';
 import { toggleEdit } from '../../Store/Actions/UiActions';
 import './portalnav.scss';
 
-const ALL_PORTFOLIOS_URL = '/insights/platform/service-portal/portfolios';
-const PLATFORM_ITEM_URL_BASE = `/insights/platform/service-portal/platform_items/platform=`;
-const PORTFOLIO_URL_BASE = `/insights/platform/service-portal/portfolios/`;
+const ALL_PORTFOLIOS_URL = '/portfolios';
+const PLATFORM_ITEM_URL_BASE = '/platform_items';
+const PORTFOLIO_URL_BASE = '/portfolios';
 
 class PortalNav extends React.Component {
     state = {
@@ -22,10 +22,9 @@ class PortalNav extends React.Component {
 
     componentDidMount() {
       this.fetchData();
-      bindMethods(this, [ 'onSelect' ]);
     }
 
-    fetchData() {
+    fetchData = () => {
     // TODO - only call if the user is an admin
       this.props.fetchPlatforms();
       this.props.fetchPortfolios();
@@ -34,13 +33,17 @@ class PortalNav extends React.Component {
     platformNavItems = () => {
       if (this.props.platforms) {
         return this.props.platforms.map(item => (
-          <NavItem key={ item.id }
-            itemId={ item.id }
-            groupId="platforms"
-            to={ PLATFORM_ITEM_URL_BASE + `${item.id}` }
+          <NavLink
+            key={ item.id }
+            to={ `${PLATFORM_ITEM_URL_BASE}/${item.id}` }
           >
-            { item.name }
-          </NavItem>
+            <NavItem
+              itemId={ item.id }
+              groupId="platforms"
+            >
+              { item.name }
+            </NavItem>
+          </NavLink>
         ));
       }
       else {
@@ -51,13 +54,16 @@ class PortalNav extends React.Component {
     portfolioNavItems = () => {
       if (this.props.portfolios) {
         return this.props.portfolios.map(item => (
-          <NavItem
+          <NavLink
             key={ item.id }
-            groupId="portfolios"
-            to={ PORTFOLIO_URL_BASE + `${item.id}` }
+            to={ `${PORTFOLIO_URL_BASE}/${item.id}` }
           >
-            { item.name }
-          </NavItem>
+            <NavItem
+              groupId="portfolios"
+            >
+              { item.name }
+            </NavItem>
+          </NavLink>
         ));
       } else {
         return null;
@@ -75,13 +81,16 @@ class PortalNav extends React.Component {
           { !this.props.isPlatformDataLoading && this.platformNavItems() }
         </NavGroup>
         <NavGroup title="Portfolios">
-          <NavItem
+          <NavLink
             key='all'
-            groupId="portfolios"
             to={ ALL_PORTFOLIOS_URL }
           >
-                    All Portfolios
-          </NavItem>
+            <NavItem
+              groupId="portfolios"
+            >
+              All Portfolios
+            </NavItem>
+          </NavLink>
           { !this.props.isLoading && this.portfolioNavItems() }
         </NavGroup>
       </Nav>;
@@ -95,11 +104,11 @@ const mapStateToProps = state => ({
   portfolios: state.PortfolioStore.portfolios
 });
 
-const mapDispatchToProps = dispatch => ({
-  fetchPlatforms: () => dispatch(fetchPlatforms()),
-  fetchPortfolios: () => dispatch(fetchPortfolios()),
-  toggleEdit: () => dispatch(toggleEdit())
-});
+const mapDispatchToProps = dispatch => bindActionCreators({
+  fetchPlatforms,
+  fetchPortfolios,
+  toggleEdit
+}, dispatch);
 
 PortalNav.propTypes = {
   portfolios: propTypes.array,


### PR DESCRIPTION
## Changes
- Using `NavItem` from `react-router-dom`
- Replaced absolute link paths with service-portal paths
- Enabled hot-reloading in webpack
- Fix insights route to render `Route` and not component
  - this fixes route params. No need for `computedMatch` anymore