### PR TITLE
Remove components from redux

### DIFF
--- a/src/Helpers/Platform/PlatformHelper.js
+++ b/src/Helpers/Platform/PlatformHelper.js
@@ -1,5 +1,3 @@
-import React from 'react';
-import PlatformItem from '../../PresentationalComponents/Platform/PlatformItem';
 import { getTopologicalUserApi } from '../Shared/userLogin';
 
 const api = getTopologicalUserApi();
@@ -18,16 +16,5 @@ export function getPlatformItems(apiProps) {
     apiPromise = api.listServiceOfferings();
   }
 
-  return apiPromise.then(data => processPlatformItems(data), error => console.error(error));
-}
-
-function processPlatformItems(items) {
-  return { platformItems: items.map((item, row) => processPlatformItem(row, item)) };
-}
-
-// remove rendering from Helper
-// Also why storing React components into Redux?
-function processPlatformItem(key, data) {
-  return <PlatformItem key={ key } { ...data } />;
-}
-
+  return apiPromise.then(data => data, error => console.error(error));
+};

--- a/src/PresentationalComponents/Platform/PlatformItem.js
+++ b/src/PresentationalComponents/Platform/PlatformItem.js
@@ -1,15 +1,13 @@
 import React from 'react';
-import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import './platformitem.scss';
 import propTypes from 'prop-types';
 import CatItemSvg from '../../assets/images/vendor-openshift.svg';
 import ImageWithDefault from '../Shared/ImageWithDefault';
 import { hideModal, showModal } from '../../redux/Actions/MainModalActions';
-import { GridItem, Card, CardHeader, CardBody, CardFooter } from '@patternfly/react-core';
+import { GridItem, Card, CardHeader, CardBody } from '@patternfly/react-core';
 import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle } from '@patternfly/react-core';
-import itemDetails from '../../PresentationalComponents/Shared/CardCommon';
-import { bindMethods } from '../../Helpers/Shared/Helper';
+import ItemDetails from '../../PresentationalComponents/Shared/CardCommon';
 
 const TO_DISPLAY = [ 'description' ];
 
@@ -23,33 +21,24 @@ const mapDispatchToProps = dispatch => {
 };
 
 class PlatformItem extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { isOpen: true, showMenu: false };
-    bindMethods(this, [ 'onSelect', 'handleMenuOpen', 'handleMenuClose', 'showPortfolioMenu', 'hidePortfolioMenu' ]);
+  state = {
+    isOpen: true,
+    showMenu: false
   };
 
-  handleMenuOpen() {
-    this.setState({ isOpen: true });
-  }
+  handleMenuOpen = () => this.setState({ isOpen: true });
 
-  handleMenuClose() {
-    this.setState({ isOpen: false });
-  }
+  handleMenuClose = () => this.setState({ isOpen: false });
 
-  showPortfolioMenu() {
-    this.setState({ showMenu: true });
-  }
+  showPortfolioMenu = () => this.setState({ showMenu: true });
 
-  hidePortfolioMenu() {
-    this.setState({ showMenu: false });
-  }
+  hidePortfolioMenu = () => this.setState({ showMenu: false });
 
   portfolioOptions = [
     { value: 'new', label: 'Add Portfolio', disabled: false }
   ];
 
-  addPortfolioOptions() {
+  addPortfolioOptions = () => {
     //for each portfolio in portfolios, add an option in the portfolioOptions array
   };
 
@@ -69,7 +58,7 @@ class PlatformItem extends React.Component {
 
   render() {
     return (
-      <GridItem key={ this.props.id } GridItem sm={ 6 } md={ 4 } lg={ 4 } xl={ 3 }>
+      <GridItem sm={ 6 } md={ 4 } lg={ 4 } xl={ 3 }>
         <Card onMouseEnter = { this.showPortfolioMenu }
           onMouseLeave = { this.hidePortfolioMenu }
         >
@@ -87,17 +76,15 @@ class PlatformItem extends React.Component {
                     toggle={ <DropdownToggle onToggle={ this.onToggle }> Portfolio </DropdownToggle> }
                     id="dropdown-menu" itemdata={ [ this.props ] }
                   >
-                    <DropdownItem key="action" component="button">
-                            Add Portfolio
+                    <DropdownItem component="button">
+                      Add Portfolio
                     </DropdownItem>
                   </Dropdown>
                 </div>
               }
               <h4>{ this.props.name }</h4>
-              { itemDetails(this.props, TO_DISPLAY) }
+              { <ItemDetails { ...this.props } toDisplay={ TO_DISPLAY } /> }
             </CardBody>
-            <CardFooter>
-            </CardFooter>
           </div>
         </Card>
       </GridItem>
@@ -114,9 +101,4 @@ PlatformItem.propTypes = {
   name: propTypes.string
 };
 
-export default withRouter(
-  connect(
-    null,
-    mapDispatchToProps)(PlatformItem)
-);
-
+export default connect(null, mapDispatchToProps)(PlatformItem);

--- a/src/PresentationalComponents/Shared/CardCommon.js
+++ b/src/PresentationalComponents/Shared/CardCommon.js
@@ -1,23 +1,32 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
-const propLine = value => <div className = "card_element">{ value }</div>;
+// This whole thing is a bit strange
+const PropLine = ({ value }) => <div className = "card_element">{ value }</div>;
 
-const hasOwnValidDisplayProperty = (item, property, toDisplay) =>
-  (item.hasOwnProperty(property) && toDisplay.includes(property) && item[property] && item[property] !== undefined);
-
-const propertyDetails = (item, toDisplay) => {
-  let details = [];
-  // MAP not for in
-  for (let property in item) {
-    if (hasOwnValidDisplayProperty(item, property, toDisplay)) {
-      details.push(propLine(property, item[property].toString()));
-    }
-  }
-
-  return details;
+PropLine.propTypes = {
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.arrayOf(PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ]))
+  ]).isRequired
 };
 
-// Should be component not function
-const itemDetails = (props, toDisplay) => <div>{ propertyDetails(props, toDisplay) }</div>;
+const ItemDetails = ({ toDisplay = [], ...item }) => (
+  <div>
+    { toDisplay.map(prop => <PropLine key={ `card-prop-${prop}` } value={ item[prop] } />) }
+  </div>
+);
 
-export default itemDetails;
+ItemDetails.propTypes = {
+  toDisplay: PropTypes.arrayOf(PropTypes.string)
+};
+
+ItemDetails.defaultProps = {
+  toDisplay: []
+};
+
+export default ItemDetails;

--- a/src/SmartComponents/Platform/PlatformItems.js
+++ b/src/SmartComponents/Platform/PlatformItems.js
@@ -7,6 +7,7 @@ import { fetchPlatformItems } from '../../redux/Actions/PlatformActions';
 import { Toolbar, ToolbarGroup, ToolbarItem, ToolbarSection } from '@patternfly/react-core';
 import ContentGallery from '../../SmartComponents/ContentGallery/ContentGallery';
 import MainModal from '../Common/MainModal';
+import PlatformItem from '../../PresentationalComponents/Platform/PlatformItem';
 import './platformitems.scss';
 
 class PlatformItems extends Component {
@@ -46,7 +47,7 @@ class PlatformItems extends Component {
 
   render() {
     let filteredItems = {
-      items: this.props.platformItems.platformItems,
+      items: this.props.platformItems.map(data => <PlatformItem key={ data.id } { ...data } />),
       isLoading: this.props.isLoading
     };
     return (

--- a/src/SmartComponents/Portfolio/PortfolioItem.js
+++ b/src/SmartComponents/Portfolio/PortfolioItem.js
@@ -29,7 +29,7 @@ class PortfolioItem extends React.Component {
 
     render() {
       return (
-        <GridItem GridItem sm={ 6 } md={ 4 } lg={ 4 } xl={ 3 }>
+        <GridItem sm={ 6 } md={ 4 } lg={ 4 } xl={ 3 }>
           <Card>
             <div onClick={ () => {this.handleOnClick(this.props);} }>
               <CardHeader className="card_header">


### PR DESCRIPTION
### Changes
- CardCommon
  - using React component rather than js function
  - now is rendering props listed in `toDisplay`
    - this revealed a styling issue of the CommoCard
    - text is overflowing if its too long.
    - we should add some ellipsis property rather than just cut of the text
  - fixed issue with non unique component `key`
- PlatformHelper
  - is no longer storing React component into redux store
  - now just holds data necessary for rendering those components
- PlatformItems
  - now handles rendering of components that were stored inside redux.
 

Also i had some issues with default props will investigate.

The CommonCard is too generic imo. There are no rules other than the toDisplay array. I would prefer a bit more strict approach, because it will break and does not allow any further customization. Probably passing just children to the CardBody would be preferable. But it can be done later.